### PR TITLE
fix(setup): update package_data to include all static files; fix(icon path): correct path resolution for FluentIcon

### DIFF
--- a/fluentflet/utils/fluent_icons.py
+++ b/fluentflet/utils/fluent_icons.py
@@ -1522,7 +1522,7 @@ class FluentIcon(ft.Image):
         size: int = 24,
     ):
         if name in FluentIcons:
-            icon_path = Path(__file__).parent.joinpath(
+            icon_path = Path(__file__).parent.parent.joinpath(
                 "static",
                 "icons",
                 ICON_TEMPLATE.format(

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(),
-    package_data={"fluentflet": ["static/*"]},
+    package_data={"fluentflet": ["static/**/*", "static/*"]},
     include_package_data=True,
     python_requires=">=3.7",
     install_requires=[


### PR DESCRIPTION
Hi,

I have now tried out your fix for the Fluent Icons not being included in the package but it's now looking in the incorrect location. See the below error:

`FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\USER\\AppData\\Local\\Programs\\Python\\Python312\\Lib\\site-packages\\fluentflet\\utils\\static\\icons\\ic_fluent_add_24_regular.svg'`

The static folder was located in the root of fluentflet and there was no utils folder. I have gone and corrected this in both fluent_icons.py and setup.py as to include all the files from static properly. I have tested this on my end and now the Fluent Icons are functioning.

Let me know if you have any questions!