### PR TITLE
Update fluent_icons.py: line 1526, affecting the icon path

### DIFF
--- a/fluentflet/utils/fluent_icons.py
+++ b/fluentflet/utils/fluent_icons.py
@@ -1523,7 +1523,7 @@ class FluentIcon(ft.Image):
     ):
         if name in FluentIcons:
             icon_path = Path(__file__).parent.parent.joinpath(
-                "static",
+                "../static",
                 "icons",
                 ICON_TEMPLATE.format(
                     name=name.value, size=ICON_SIZE, style=style.value


### PR DESCRIPTION
The change is this error `FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\Rodern\\git-repos\\inventory-plus\\.venv\\Lib\\site-packages\\fluentflet\\utils\\static\\icons\\ic_fluent_add_24_regular.svg'` when the application is executed.

My fix to it was to adjust the icons path